### PR TITLE
[MJMOD-20] set jmod --main-class argument if it is set.

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jmod/JModCreateMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jmod/JModCreateMojo.java
@@ -587,6 +587,12 @@ public class JModCreateMojo
             argsFile.println( getPlatformSeparatedList( configList ) );
         }
 
+        if ( mainClass != null && !mainClass.isBlank() )
+        {
+            argsFile.println( "--main-class" );
+            argsFile.println( mainClass );
+        }
+
         List<String> cmdsList = handleConfigurationListWithDefault( cmds, DEFAULT_CMD_DIRECTORY );
         if ( !cmdsList.isEmpty() )
         {


### PR DESCRIPTION
Hi!

This pull request sets the parameter --main-class if it was set in:

```
<plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-jmod-plugin</artifactId>
                <configuration>
                    <mainClass>com.andretadeu.greetings.Main</mainClass>
                    <modulePath>target/jmods</modulePath>
                    <moduleVersion>${project.version}</moduleVersion>
                </configuration>
...
</plugin>
```

otherwise, if I am not able to set, I may not run jmod in modules that contains a Main class.

Thanks,

André Tadeu de Carvalho