### PR TITLE
[MJMOD-8] NullPointerException on create

### DIFF
--- a/src/it/mjmod-8-generate-jmod-in-other-project/about-cli-app/pom.xml
+++ b/src/it/mjmod-8-generate-jmod-in-other-project/about-cli-app/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jmod-plugin-mjmod-8</artifactId>
+        <version>99.0</version>
+    </parent>
+
+    <artifactId>about-cli-app</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>2.0.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/src/it/mjmod-8-generate-jmod-in-other-project/about-cli-app/src/main/java/module-info.java
+++ b/src/it/mjmod-8-generate-jmod-in-other-project/about-cli-app/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module mymodule.about.cli {
+  requires java.base;
+  requires static info.picocli;
+  exports mymodule.about.cli;
+}

--- a/src/it/mjmod-8-generate-jmod-in-other-project/about-cli-app/src/main/java/mymodule/about/cli/Main.java
+++ b/src/it/mjmod-8-generate-jmod-in-other-project/about-cli-app/src/main/java/mymodule/about/cli/Main.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package mymodule.about.cli;
+
+import picocli.CommandLine;
+
+import static picocli.CommandLine.*;
+
+@Command(
+        name = "Main",
+        description = "Demonstrating picocli",
+        headerHeading = "Demonstration Usage:%n%n")
+public class Main {
+
+    @Option(names = {"-v", "--verbose"}, description = "Verbose output?")
+    private boolean verbose;
+
+    @Option(names = {"-f", "--file"}, description = "Path and name of file", required = true)
+    private String fileName;
+
+    @Option(names = {"-h", "--help"}, description = "Display help/usage.", help = true)
+    boolean help;
+
+    public static void main(String[] arguments) {
+
+        final Main main = CommandLine.populateCommand(new Main(), arguments);
+
+        if (main.help) {
+            CommandLine.usage(main, System.out, CommandLine.Help.Ansi.AUTO);
+        } else {
+            System.out.println("The provided file path and name is " + main.fileName + " and verbosity is set to " + main.verbose);
+        }
+    }
+}

--- a/src/it/mjmod-8-generate-jmod-in-other-project/about-cli-distribution-jmod/pom.xml
+++ b/src/it/mjmod-8-generate-jmod-in-other-project/about-cli-distribution-jmod/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jmod-plugin-mjmod-8</artifactId>
+        <version>99.0</version>
+    </parent>
+
+    <artifactId>about-cli-distribution-jmod</artifactId>
+    <packaging>jmod</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>about-cli-app</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jmod-plugin</artifactId>
+                <extensions>true</extensions>
+                <!-- <configuration>
+                    <classPath>
+                        ${project.parent.basedir}/about-cli-app/target/about-cli-app-${project.version}.jar
+                    </classPath>
+                </configuration> -->
+                <executions>
+                    <execution>
+                        <id>list</id>
+                        <goals>
+                            <goal>list</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                    <execution>
+                        <id>describe</id>
+                        <goals>
+                            <goal>describe</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/it/mjmod-8-generate-jmod-in-other-project/about-cli-distribution-jmod/src/main/cmds/about
+++ b/src/it/mjmod-8-generate-jmod-in-other-project/about-cli-distribution-jmod/src/main/cmds/about
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+JLINK_VM_OPTIONS=
+DIR=`dirname $0`
+$DIR/java $JLINK_VM_OPTIONS -m mymodule.about.cli.jar/mymodule.about.cli.Main $@
+

--- a/src/it/mjmod-8-generate-jmod-in-other-project/about-cli-distribution-jmod/src/main/configs/about.yaml
+++ b/src/it/mjmod-8-generate-jmod-in-other-project/about-cli-distribution-jmod/src/main/configs/about.yaml
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+Test

--- a/src/it/mjmod-8-generate-jmod-in-other-project/invoker.properties
+++ b/src/it/mjmod-8-generate-jmod-in-other-project/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+invoker.java.version = 9+
+invoker.goals = package

--- a/src/it/mjmod-8-generate-jmod-in-other-project/pom.xml
+++ b/src/it/mjmod-8-generate-jmod-in-other-project/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-jmod-plugin-mjmod-8</artifactId>
+    <version>99.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <modules>
+        <module>about-cli-app</module>
+        <module>about-cli-distribution-jmod</module>
+    </modules>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.0</version>
+                    <configuration>
+                        <release>9</release>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jmod-plugin</artifactId>
+                    <version>@project.version@</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+    </build>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>apache.snapshots</id>
+            <url>http://repository.apache.org/snapshots/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+</project>

--- a/src/it/mjmod-8-generate-jmod-in-other-project/verify.groovy
+++ b/src/it/mjmod-8-generate-jmod-in-other-project/verify.groovy
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
+
+
+println( "Checking if ${basedir}/about-cli-app/target exists." )
+File target = new File( basedir, "/about-cli-app/target" )
+assert target.isDirectory()
+
+File artifact = new File( basedir, "/about-cli-distribution-jmod/target/jmods/about-cli-distribution-jmod.jmod" )
+assert artifact.isFile()
+
+String[] artifactNames = [
+        "classes/module-info.class",
+        "classes/META-INF/MANIFEST.MF",
+        "classes/mymodule/about/cli/Main.class",
+        "classes/META-INF/maven/org.apache.maven.plugins/about-cli-app/pom.xml",
+        "classes/META-INF/maven/org.apache.maven.plugins/about-cli-app/pom.properties",
+        "conf/about.yaml",
+        "bin/about"
+]
+
+Set contents = new HashSet()
+
+JarFile jar = new JarFile( artifact )
+Enumeration jarEntries = jar.entries()
+while ( jarEntries.hasMoreElements() )
+{
+    JarEntry entry = (JarEntry) jarEntries.nextElement()
+    println( "Current entry: ${entry}" )
+    if ( !entry.isDirectory() )
+    {
+        // Only compare files
+        contents.add( entry.getName() )
+    }
+}
+
+println( "Comparing the expected number of files with the actual number of files" )
+assert artifactNames.length == contents.size()
+
+artifactNames.each{ artifactName ->
+    println( "Does ${artifactName} exist in content." )
+    assert contents.contains( artifactName )
+}
+
+return true


### PR DESCRIPTION
Hi,

I created this pull request to fulfill to address the need to set **--class-path** parameter from _jmod create_, because it offers the possibility to create a JMOD artifact from a JAR created in another project, in a Maven multi-module context.

Commit comment:

> NullPointerException happens when I am trying to create a JMOD from a JAR from another project. The plugin was not setting classPath when it should to run the following command: 'jmod create --class-path <JAR location> <target>'.

Thanks,

André Tadeu de Carvalho