### PR TITLE
[MJMOD-23] Add modularized JARs parent's path instead of theirs.

### DIFF
--- a/src/it/mjmod-23-path-must-be-dir/greetings/pom.xml
+++ b/src/it/mjmod-23-path-must-be-dir/greetings/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jmod-plugin-mjmod-23</artifactId>
+        <version>99.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>myproject.greetings</artifactId>
+    <packaging>jmod</packaging>
+
+    <name>myproject.greetings</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>myproject.world</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>myproject.greetings.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>client</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jmod-plugin</artifactId>
+                <configuration>
+                    <mainClass>myproject.greetings.Main</mainClass>
+                    <modulePath>target/jmods</modulePath>
+                    <moduleVersion>${project.version}</moduleVersion>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>list</id>
+                        <goals>
+                            <goal>list</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                    <execution>
+                        <id>describe</id>
+                        <goals>
+                            <goal>describe</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/mjmod-23-path-must-be-dir/greetings/src/main/java/module-info.java
+++ b/src/it/mjmod-23-path-must-be-dir/greetings/src/main/java/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module myproject.greetings {
+    requires myproject.world;
+}

--- a/src/it/mjmod-23-path-must-be-dir/greetings/src/main/java/myproject/greetings/Main.java
+++ b/src/it/mjmod-23-path-must-be-dir/greetings/src/main/java/myproject/greetings/Main.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package myproject.greetings;
+
+import myproject.world.World;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.format("Greetings %s!%n", World.name());
+    }
+}
+

--- a/src/it/mjmod-23-path-must-be-dir/invoker.properties
+++ b/src/it/mjmod-23-path-must-be-dir/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+invoker.java.version = 9+
+invoker.goals = verify

--- a/src/it/mjmod-23-path-must-be-dir/pom.xml
+++ b/src/it/mjmod-23-path-must-be-dir/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-jmod-plugin-mjmod-23</artifactId>
+    <version>99.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>myproject.world</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.0</version>
+                    <configuration>
+                        <release>9</release>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jmod-plugin</artifactId>
+                <version>@project.version@</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <modules>
+        <module>world</module>
+        <module>greetings</module>
+    </modules>
+
+</project>

--- a/src/it/mjmod-23-path-must-be-dir/verify.groovy
+++ b/src/it/mjmod-23-path-must-be-dir/verify.groovy
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
+
+validateArtifact( "world", "/myproject.world-99.0.jar",
+        [ "module-info.class",
+          "META-INF/maven/org.apache.maven.plugins/myproject.world/pom.xml",
+          "myproject/world/World.class",
+          "META-INF/maven/org.apache.maven.plugins/myproject.world/pom.properties",
+          "META-INF/MANIFEST.MF"
+        ]
+)
+validateArtifact( "greetings", "/jmods/myproject.greetings.jmod",
+        [ "classes/module-info.class",
+          "classes/myproject/greetings/Main.class" ] )
+
+def buildLog = new File(basedir,'build.log')
+
+def describeLines = buildLog.readLines()
+                            .dropWhile{ it != '[INFO] myproject.greetings@99.0' } // start line, inclusive
+                            .takeWhile{ !it.startsWith('[INFO] ---') }            // end line, inclusive
+                            .grep()                                               // remove empty lines
+                            .collect{ it - '[INFO] ' } as Set                        // strip loglevel
+
+def expectedLines = [
+                "myproject.greetings@99.0",
+                "requires java.base mandated",
+                "requires myproject.world",
+                "contains myproject.greetings",
+                "main-class myproject.greetings.Main"] as Set
+
+assert describeLines == expectedLines
+
+def validateArtifact(module, String filename, resourceNames)
+{
+    println( "Checking if ${basedir}/${module}/target exists." )
+    def targetDir = new File( basedir, "/${module}/target" )
+    assert targetDir.isDirectory()
+
+    File artifact = new File( targetDir, filename )
+    assert artifact.isFile()
+
+    Set contents = new HashSet()
+
+    JarFile jar = new JarFile( artifact )
+    Enumeration jarEntries = jar.entries()
+    while ( jarEntries.hasMoreElements() )
+    {
+        JarEntry entry = (JarEntry) jarEntries.nextElement()
+        println( "Current entry: ${entry}" )
+        if ( !entry.isDirectory() )
+        {
+            // Only compare files
+            contents.add( entry.getName() )
+        }
+    }
+
+    assert resourceNames.size() == contents.size()
+
+    resourceNames.each{ artifactName ->
+        assert contents.contains( artifactName )
+    }
+}

--- a/src/it/mjmod-23-path-must-be-dir/world/pom.xml
+++ b/src/it/mjmod-23-path-must-be-dir/world/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jmod-plugin-mjmod-23</artifactId>
+        <version>99.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>myproject.world</artifactId>
+
+    <name>myproject.world</name>
+
+</project>

--- a/src/it/mjmod-23-path-must-be-dir/world/pom.xml
+++ b/src/it/mjmod-23-path-must-be-dir/world/pom.xml
@@ -31,4 +31,56 @@
 
     <name>myproject.world</name>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>client</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/it/mjmod-23-path-must-be-dir/world/src/main/java/module-info.java
+++ b/src/it/mjmod-23-path-must-be-dir/world/src/main/java/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module myproject.world {
+    exports myproject.world;
+}

--- a/src/it/mjmod-23-path-must-be-dir/world/src/main/java/myproject/world/World.java
+++ b/src/it/mjmod-23-path-must-be-dir/world/src/main/java/myproject/world/World.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package myproject.world;
+
+public class World {
+    public static String name() {
+        return "world";
+    }
+}

--- a/src/main/java/org/apache/maven/plugins/jmod/JModCreateMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jmod/JModCreateMojo.java
@@ -497,7 +497,14 @@ public class JModCreateMojo
                 for ( File file : resolvePathsResult.getModulepathElements().keySet() )
                 {
                     getLog().debug( "modulepathElements: File: " + file.getPath() );
-                    modulepathElements.add( file.getPath() );
+                    if ( file.isDirectory() )
+                    {
+                        modulepathElements.add( file.getPath() );
+                    }
+                    else
+                    {
+                        modulepathElements.add( file.getParent() );
+                    }
                 }
             }
             catch ( IOException e )


### PR DESCRIPTION
Hi!

In this PR, I changed the way the parameter **--module-path** is built for **jmod create**. In the original code, the modularized JAR dependencies' full path were added, instead of their parent folder. Since **jmod create** requires that **--module-path** entries to be folders only, I am getting the JAR's parent folder.

Thanks in advance,