### PR TITLE
[MNG-6825] Replace org.apache.maven.shared.utils.StringUtils

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jmod/JModCreateMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jmod/JModCreateMojo.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -37,7 +38,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.shared.utils.StringUtils;
 import org.apache.maven.shared.utils.logging.MessageUtils;
 import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.java.DefaultJavaToolChain;


### PR DESCRIPTION
So from https://issues.apache.org/jira/browse/MNG-6825 it seems the goal is to reduce the dependency on `org.apache.maven.shared.utils.StringUtils`, and replace that with `org.apache.commons.lang3.StringUtils` when also a dependency. (Unless I misunderstood). This is a first step towards that, after which only `MessageUtils` is holding up dropping `maven-shared-utils`.