### PR TITLE
Add check if JMOD-Folder exists

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jmod/JModCreateMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jmod/JModCreateMojo.java
@@ -18,8 +18,6 @@
  */
 package org.apache.maven.plugins.jmod;
 
-import javax.inject.Inject;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -27,7 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
+import javax.inject.Inject;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -295,6 +293,11 @@ public class JModCreateMojo extends AbstractJModMojo {
             File jmodsFolderJDK = new File(javaHome, JMODS);
             getLog().debug("Parent: " + javaHome.getAbsolutePath());
             getLog().debug("jmodsFolder: " + jmodsFolderJDK.getAbsolutePath());
+
+            if (!jmodsFolderJDK.exists()) {
+                throw new IOException(
+                        "JMODS folder does not exists. You might use a JDK which does not ship this anymore due to JEP 493 (Java 24).");
+            }
 
             preparePaths();
 

--- a/src/main/java/org/apache/maven/plugins/jmod/JModCreateMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jmod/JModCreateMojo.java
@@ -296,7 +296,7 @@ public class JModCreateMojo extends AbstractJModMojo {
 
             if (!jmodsFolderJDK.exists()) {
                 throw new IOException(
-                        "JMODS folder does not exists. You might use a JDK which does not ship this anymore due to JEP 493 (Java 24).");
+                        "JMODS folder does not exists. You might use a JDK which does not ship this anymore due to JEP 493 (Java 24). For more information also see: https://openjdk.org/jeps/493");
             }
 
             preparePaths();

--- a/src/main/java/org/apache/maven/plugins/jmod/JModCreateMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jmod/JModCreateMojo.java
@@ -18,6 +18,8 @@
  */
 package org.apache.maven.plugins.jmod;
 
+import javax.inject.Inject;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -25,7 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import javax.inject.Inject;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -30,9 +30,6 @@ ${project.name}
 
   The JMod Plugin is used to create {{{http://openjdk.java.net/jeps/261}JMod Files}}.
 
-  NOTE: This is an alpha release which means everything can change until we reach the first
-  milestone release.
-
 * Goals Overview
 
   The JMod Plugin has currently two goals:
@@ -51,6 +48,8 @@ ${project.name}
 
   General instructions on how to use the JMod Plugin can be found on the {{{./usage.html}usage page}}. Some more
   specific use cases are described in the examples given below.
+
+  <<Java 24+ Users:>> Please be aware of the changes introduced with {{{./jep493.html}JEP 493}}!
 
   In case you still have questions regarding the plugin's usage, please have a look at the {{{./faq.html}FAQ}} and feel
   free to contact the {{{./mailing-lists.html}user mailing list}}. The posts to the mailing list are archived and could

--- a/src/site/markdown/jep493.md
+++ b/src/site/markdown/jep493.md
@@ -1,0 +1,31 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# JEP 493: Linking Run-Time Images without JMODs
+
+Java 24 introduced ["JEP 493: Linking Run-Time Images without JMODs"](https://openjdk.org/jeps/493).
+Goal of this JEP is to reduce JDK size by about 25%, by removing the JDK's own JMOD files.
+This means that since Java 24 each JDK vendor decides if they support the new option or ship the JMOD files.
+For example the [Eclipse Temurin JDK](https://adoptium.net/news/2025/08/eclipse-temurin-jdk24-JEP493-enabled) does not ship these files anymore since Java 24.
+
+The Maven JMod Plugin depends on the existence of the `/jmods` folder of the used JDK (configured via `JAVA_HOME`) and will fail if this directory does not exist.
+If you want to use the Maven JMod Plugin make sure to either use a JDK which still ships the JDK's own JMOD files natively or try to download them in addition to the JDK.
+
+In the long term the JDK team suggest to link run-time images without JMODs as introduced in the JEP.
+

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -29,6 +29,7 @@ under the License.
       <!-- According to https://issues.apache.org/jira/browse/MNGSITE-152 -->
       <item name="License" href="https://www.apache.org/licenses/"/>
       <item name="Download" href="download.html"/>
+      <item name="JEP 493: Linking Run-Time Images Without JMODs" href="jep493.html"/>
     </menu>
     <menu name="Examples">
       <item name="Describe Goal" href="examples/example-describe.html"/>


### PR DESCRIPTION
The JMOD folder is not part of the OpenJDK since Java 24 due JEP 493. Some vendors still add the folder, but some do not.