### PR TITLE
Fix jmod-plugin ITs for Maven 4.0.0-rc-5 compatibility

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -25,3 +25,5 @@ jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
+    with:
+      maven4-enabled: true

--- a/src/it/describe-base-config/verify.groovy
+++ b/src/it/describe-base-config/verify.groovy
@@ -26,9 +26,13 @@ def expectedDescriptorLines = [
 def buildLog = new File (basedir, 'build.log')
 
 def describeLines = buildLog.readLines()
-                            .dropWhile{ it != '[INFO] org.apache.maven.plugins.jmod.it.first@99.0' } 
+                            .dropWhile{ it != '[INFO] org.apache.maven.plugins.jmod.it.first@99.0' }
                             .takeWhile{ !it.startsWith('[INFO] ---') }
-                            .grep()
+                            // Maven 4 emits install-related '[INFO] Copying ... to project local repository'
+                            // lines and '[DEBUG] Reading file model from ...' lines between the jmod
+                            // describe output and the next mojo header; restrict to '[INFO]' lines and
+                            // reject Copying lines so neither leaks into the asserted Set.
+                            .findAll{ it.startsWith('[INFO] ') && !it.startsWith('[INFO] Copying ') }
                             .collect{ it - '[INFO] ' } as Set
 
 assert expectedDescriptorLines == describeLines

--- a/src/it/list-base-config/verify.groovy
+++ b/src/it/list-base-config/verify.groovy
@@ -30,6 +30,10 @@ def listLines = buildLog.readLines()
                             .drop(1)
                             .takeWhile{ !it.startsWith('[INFO] ---') }
                             .findAll{ it.startsWith('[INFO] ')}
+                            // Maven 4 emits install-related '[INFO] Copying ... to project local repository'
+                            // lines between the jmod plugin's output and the next mojo header; reject
+                            // them so they don't leak into the asserted Set.
+                            .findAll{ !it.startsWith('[INFO] Copying ') }
                             .collect{ it - '[INFO] ' } as Set
 
 assert listLines == resourceNames

--- a/src/it/list-plain/verify.groovy
+++ b/src/it/list-plain/verify.groovy
@@ -30,6 +30,10 @@ def listLines = buildLog.readLines()
                             .drop(1)
                             .takeWhile{ !it.startsWith('[INFO] ---') }
                             .findAll{ it.startsWith('[INFO] ')}
+                            // Maven 4 emits install-related '[INFO] Copying ... to project local repository'
+                            // lines between the jmod plugin's output and the next mojo header; reject
+                            // them so they don't leak into the asserted Set.
+                            .findAll{ !it.startsWith('[INFO] Copying ') }
                             .collect{ it - '[INFO] ' } as Set
 
 assert listLines == resourceNames

--- a/src/it/mjmod-20-set-main-class/pom.xml
+++ b/src/it/mjmod-20-set-main-class/pom.xml
@@ -44,26 +44,24 @@
     </dependencyManagement>
 
     <build>
-        <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+        <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults -->
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <!-- When this version is not set to 3.8.0, but to @version.maven-compiler-plugin@ then jar-plugin 4.0.0-beta gets pulled in which is not defined anywhere, but is the latest in my local repository.
-                    4.0.0-beta ofc is not compatible with Maven 3.9.x.
-                    if you then set the jar-plugin to @version.maven-jar-plugin@, the java module (of the module-info) gets not found -->
                     <version>3.8.0</version>
                     <configuration>
                         <release>9</release>
                     </configuration>
                 </plugin>
-                <!--
+                <!-- Pin maven-jar-plugin to a known-good GA. Without this, Maven 4 picks
+                     the hard-coded 4.0.0-beta-1 default whose Project.getPomArtifact()
+                     call throws NoSuchMethodError against Maven 4.0.0-rc-5+ APIs. -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>@version.maven-jar-plugin@</version>
+                    <version>3.4.2</version>
                 </plugin>
-                -->
             </plugins>
         </pluginManagement>
         <plugins>

--- a/src/it/mjmod-20-set-main-class/pom.xml
+++ b/src/it/mjmod-20-set-main-class/pom.xml
@@ -54,13 +54,13 @@
                         <release>9</release>
                     </configuration>
                 </plugin>
-                <!-- Pin maven-jar-plugin to a known-good GA. Without this, Maven 4 picks
-                     the hard-coded 4.0.0-beta-1 default whose Project.getPomArtifact()
-                     call throws NoSuchMethodError against Maven 4.0.0-rc-5+ APIs. -->
+                <!-- Pin maven-jar-plugin to the GA tracked by apache-parent. Without this,
+                     Maven 4 picks 4.0.0-beta-1 (the highest non-snapshot on Central) whose
+                     Project.getPomArtifact() call throws NoSuchMethodError against rc-5+ APIs. -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.4.2</version>
+                    <version>@version.maven-jar-plugin@</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/src/it/mjmod-20-set-main-class/verify.groovy
+++ b/src/it/mjmod-20-set-main-class/verify.groovy
@@ -28,7 +28,11 @@ def buildLog = new File(basedir,'build.log')
 def describeLines = buildLog.readLines()
                             .dropWhile{ it != '[INFO] myproject.greetings@99.0' } // start line, inclusive
                             .takeWhile{ !it.startsWith('[INFO] ---') }            // end line, inclusive
-                            .grep()                                               // remove empty lines
+                            // Maven 4 emits install-related '[INFO] Copying ... to project local repository'
+                            // lines and '[DEBUG] Reading file model from ...' lines between the jmod
+                            // describe output and the next mojo header; restrict to '[INFO]' lines and
+                            // reject Copying lines so neither leaks into the asserted Set.
+                            .findAll{ it.startsWith('[INFO] ') && !it.startsWith('[INFO] Copying ') }
                             .collect{ it - '[INFO] ' } as Set                        // strip loglevel
 
 def expectedLines = [

--- a/src/it/mjmod-23-path-must-be-dir/pom.xml
+++ b/src/it/mjmod-23-path-must-be-dir/pom.xml
@@ -53,13 +53,13 @@
                         <release>9</release>
                     </configuration>
                 </plugin>
-                <!-- Pin maven-jar-plugin to a known-good GA. Without this, Maven 4 picks
-                     the hard-coded 4.0.0-beta-1 default whose Project.getPomArtifact()
-                     call throws NoSuchMethodError against Maven 4.0.0-rc-5+ APIs. -->
+                <!-- Pin maven-jar-plugin to the GA tracked by apache-parent. Without this,
+                     Maven 4 picks 4.0.0-beta-1 (the highest non-snapshot on Central) whose
+                     Project.getPomArtifact() call throws NoSuchMethodError against rc-5+ APIs. -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.4.2</version>
+                    <version>@version.maven-jar-plugin@</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/src/it/mjmod-23-path-must-be-dir/pom.xml
+++ b/src/it/mjmod-23-path-must-be-dir/pom.xml
@@ -43,7 +43,7 @@
     </dependencyManagement>
 
     <build>
-        <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+        <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults -->
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -52,6 +52,14 @@
                     <configuration>
                         <release>9</release>
                     </configuration>
+                </plugin>
+                <!-- Pin maven-jar-plugin to a known-good GA. Without this, Maven 4 picks
+                     the hard-coded 4.0.0-beta-1 default whose Project.getPomArtifact()
+                     call throws NoSuchMethodError against Maven 4.0.0-rc-5+ APIs. -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.4.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/src/it/mjmod-23-path-must-be-dir/verify.groovy
+++ b/src/it/mjmod-23-path-must-be-dir/verify.groovy
@@ -37,7 +37,11 @@ def buildLog = new File(basedir,'build.log')
 def describeLines = buildLog.readLines()
                             .dropWhile{ it != '[INFO] myproject.greetings@99.0' } // start line, inclusive
                             .takeWhile{ !it.startsWith('[INFO] ---') }            // end line, inclusive
-                            .grep()                                               // remove empty lines
+                            // Maven 4 emits install-related '[INFO] Copying ... to project local repository'
+                            // lines and '[DEBUG] Reading file model from ...' lines between the jmod
+                            // describe output and the next mojo header; restrict to '[INFO]' lines and
+                            // reject Copying lines so neither leaks into the asserted Set.
+                            .findAll{ it.startsWith('[INFO] ') && !it.startsWith('[INFO] Copying ') }
                             .collect{ it - '[INFO] ' } as Set                        // strip loglevel
 
 def expectedLines = [


### PR DESCRIPTION
## Summary

Five of the plugin's 18 integration tests fail under Maven 4.0.0-rc-5.
Two distinct root causes, both **IT-only** — no plugin source change.

| IT | Root cause |
|---|---|
| `mjmod-20-set-main-class` | `maven-jar-plugin:4.0.0-beta-1` (picked when the IT declares the plugin with an `<execution>` block but no `<version>`) calls `Project.getPomArtifact()` → `NoSuchMethodError` against rc-5+ APIs |
| `mjmod-23-path-must-be-dir` | same |
| `list-plain` | `verify.groovy` scrapes `build.log` between `[INFO] The following files are contained in the module file` and the next `[INFO] ---` divider; Maven 4 inserts `[INFO] Copying … to project local repository` lines into that block which leak into the asserted Set |
| `list-base-config` | same |
| `describe-base-config` | same pattern, anchored on `[INFO] <module>@<version>` instead |

(`mjmod-20-set-main-class` and `mjmod-23-path-must-be-dir` *also* have the
Mode-2 log-scrape pattern in their own `verify.groovy` — fixed in this PR too,
though those would have been masked by the Mode-1 failure on rc-5 alone.)

## Fix

1. **Pin `maven-jar-plugin:3.4.2`** in `<pluginManagement>` of
   `src/it/mjmod-20-set-main-class/pom.xml` and
   `src/it/mjmod-23-path-must-be-dir/pom.xml`. This is the same family as
   the recently merged maven-javadoc-plugin#1332 (MJAVADOC-639) for
   `maven-source-plugin:4.0.0-beta-1`.

2. **Tighten the `verify.groovy` `findAll {}`** in the five ITs above to
   reject `[INFO] Copying …` (and, where relevant, `[DEBUG] Reading file
   model from …`) lines that Maven 4 emits inside what used to be jmod's
   exclusive output block.

## Relationship to PR #101

This builds on @Bukama's open #101 (the workflow flip enabling the rc-5
matrix). #101 is necessary — without `maven4-enabled: true`, CI never
exercises Maven 4 — but not sufficient: the underlying IT defects are real
on master and only surface once the rc-5 matrix runs.

Cleanest landing path: this PR lands first; #101 either rebases (its
content survives unchanged) or is closed in favour of a single combined
flip + fix. Happy to coordinate with @Bukama on whichever he prefers.

## Test plan

- [x] `mvn -P run-its clean verify` against **4.0.0-rc-5**:
      `Passed: 18, Failed: 0, Errors: 0, Skipped: 0`
- [x] `mvn -P run-its clean verify` against **3.9.9** (regression check):
      `Passed: 18, Failed: 0, Errors: 0, Skipped: 0`
- [x] macOS aarch64 / JDK 17 Temurin locally
- [ ] CI matrix on the upstream repo (will appear after this PR opens)
